### PR TITLE
Optimize fallback match length tail loop

### DIFF
--- a/internal/encoder/matchlen_simd_other.go
+++ b/internal/encoder/matchlen_simd_other.go
@@ -19,10 +19,8 @@ func matchLenSIMD(dataPtr unsafe.Pointer, a, b uint, limit int) int {
 			return i + bits.TrailingZeros64(xor)/8
 		}
 	}
-	for ; i < limit; i++ {
-		if *(*byte)(unsafe.Add(dataPtr, a+uint(i))) != *(*byte)(unsafe.Add(dataPtr, b+uint(i))) {
-			return i
-		}
+	for ; i < limit &&
+		*(*byte)(unsafe.Add(dataPtr, a+uint(i))) == *(*byte)(unsafe.Add(dataPtr, b+uint(i))); i++ {
 	}
 	return i
 }


### PR DESCRIPTION
Small inline optimization found when using h5:

```
  goos: darwin
  goarch: arm64
  cpu: Apple M4 Pro
  pkg: github.com/molecule-man/go-brrr/benchmarks

  name                                      old time/op  new time/op  delta
  CompressHasher/h=h5/payload=Json_8k       38.65µs      37.35µs      -3.36% (p=0.002 n=10)
  Compress/q=5/payload=Json_8k/go-brrr      38.48µs      37.26µs      -3.18% (p=0.002 n=10)

  name                                      old speed    new speed    delta
  CompressHasher/h=h5/payload=Json_8k       210.5MiB/s   217.8MiB/s   +3.48% (p=0.002 n=10)
  Compress/q=5/payload=Json_8k/go-brrr      211.4MiB/s   218.4MiB/s   +3.28% (p=0.002 n=10)

  allocs/op unchanged at 0.
```