### PR TITLE
perf(q5-q9): hand bucket scans a fixed-size array pointer

### DIFF
--- a/internal/encoder/hash5b5.go
+++ b/internal/encoder/hash5b5.go
@@ -5,7 +5,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // H5b5 configuration constants for quality 6.
 const (
@@ -40,6 +44,17 @@ type h5b5 struct {
 }
 
 func (h *h5b5) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h5b5BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h5b5HashShift, so key is always <
+// h5b5BucketSize and key<<h5b5BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h5b5BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h5b5) bucketAt(key uint32) *[h5b5BlockSize]uint32 {
+	return (*[h5b5BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h5b5BlockBits+2)))
+}
 
 // hash computes a 14-bit bucket index from 4 bytes at data[0:4].
 func (h *h5b5) hash(data []byte, i uint) uint32 {
@@ -137,11 +152,11 @@ func (h *h5b5) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively touch the next position's bucket.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	h.nextBucket = h.buckets[uint(nextKey)<<h5b5BlockBits]
+	h.nextBucket = h.bucketAt(nextKey)[0]
 
 	out.len = 0
 	out.lenCodeDelta = 0
@@ -230,7 +245,7 @@ func (h *h5b5) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b5BlockMask)+uint(key)<<h5b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -253,10 +268,10 @@ func (h *h5b5) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	h.nextBucket = h.buckets[uint(nextKey)<<h5b5BlockBits]
+	h.nextBucket = h.bucketAt(nextKey)[0]
 
 	out.len = 0
 	out.lenCodeDelta = 0
@@ -339,7 +354,7 @@ func (h *h5b5) findLongestMatchSmallBuf(
 		}
 	}
 
-	h.buckets[uint(h.num[key]&h5b5BlockMask)+uint(key)<<h5b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	if bestScore == minScore {
@@ -659,11 +674,11 @@ func (h *h5b5) findLongestMatchNoWrap(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h5b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively touch the next position's bucket.
 	nextKey := h.hash(data, cur+1)
-	h.nextBucket = h.buckets[uint(nextKey)<<h5b5BlockBits]
+	h.nextBucket = h.bucketAt(nextKey)[0]
 
 	out.len = 0
 	out.lenCodeDelta = 0
@@ -737,7 +752,7 @@ func (h *h5b5) findLongestMatchNoWrap(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b5BlockMask)+uint(key)<<h5b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash5b6.go
+++ b/internal/encoder/hash5b6.go
@@ -8,7 +8,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h5b6 configuration constants for quality 7.
 const (
@@ -39,6 +43,17 @@ type h5b6 struct {
 }
 
 func (h *h5b6) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h5b6BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h5b6HashShift, so key is always <
+// h5b6BucketSize and key<<h5b6BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h5b6BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h5b6) bucketAt(key uint32) *[h5b6BlockSize]uint32 {
+	return (*[h5b6BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h5b6BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 4 bytes at data[i:i+4].
 func (h *h5b6) hash(data []byte, i uint) uint32 {
@@ -136,18 +151,18 @@ func (h *h5b6) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b6BlockBits:]
+	bucket := h.bucketAt(key)
 	// Issue the Phase 2 num[] load early so its (often L3-miss) latency is
 	// hidden by Phase 1. n is held in a register until Phase 2.
 	n := h.num[key]
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h5b6BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b6BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h5b6BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -421,7 +436,7 @@ func (h *h5b6) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b6BlockMask)+uint(key)<<h5b6BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b6BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -444,15 +459,15 @@ func (h *h5b6) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b6BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h5b6BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b6BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h5b6BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -727,7 +742,7 @@ func (h *h5b6) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b6BlockMask)+uint(key)<<h5b6BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b6BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -1098,18 +1113,18 @@ func (h *h5b6) findLongestMatchNoWrap(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h5b6BlockBits:]
+	bucket := h.bucketAt(key)
 	// Issue the Phase 2 num[] load early so its (often L3-miss) latency is
 	// hidden by Phase 1.
 	n := h.num[key]
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, cur+1)
-	nextBase := uint(nextKey) << h5b6BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b6BlockMask)])
+		p := uint(nextBucket[(nextN-1)&h5b6BlockMask])
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -1365,7 +1380,7 @@ func (h *h5b6) findLongestMatchNoWrap(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b6BlockMask)+uint(key)<<h5b6BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b6BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash5b6u16.go
+++ b/internal/encoder/hash5b6u16.go
@@ -17,7 +17,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h5b6u16 is the h5b6 hasher with uint16 bucket slots, dispatched only when
 // the encoder expects the input to fit in 64 KiB. Configuration constants
@@ -30,6 +34,17 @@ type h5b6u16 struct {
 }
 
 func (h *h5b6u16) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h5b6BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h5b6HashShift, so key is always <
+// h5b6BucketSize and key<<h5b6BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h5b6BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h5b6u16) bucketAt(key uint32) *[h5b6BlockSize]uint16 {
+	return (*[h5b6BlockSize]uint16)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h5b6BlockBits+1)))
+}
 
 // hash computes a 15-bit bucket index from 4 bytes at data[i:i+4].
 func (h *h5b6u16) hash(data []byte, i uint) uint32 {
@@ -266,7 +281,7 @@ func (h *h5b6u16) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h5b6BlockBits:]
+	bucket := h.bucketAt(key)
 	n := h.num[key]
 
 	out.len = 0
@@ -522,7 +537,7 @@ func (h *h5b6u16) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b6BlockMask)+uint(key)<<h5b6BlockBits] = uint16(cur)
+	bucket[h.num[key]&h5b6BlockMask] = uint16(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash5b7.go
+++ b/internal/encoder/hash5b7.go
@@ -6,7 +6,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h5b7 configuration constants for quality 8.
 const (
@@ -42,6 +46,17 @@ type h5b7 struct {
 }
 
 func (h *h5b7) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h5b7BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h5b7HashShift, so key is always <
+// h5b7BucketSize and key<<h5b7BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h5b7BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h5b7) bucketAt(key uint32) *[h5b7BlockSize]uint32 {
+	return (*[h5b7BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h5b7BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 4 bytes at data[i:i+4].
 func (h *h5b7) hash(data []byte, i uint) uint32 {
@@ -139,18 +154,18 @@ func (h *h5b7) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b7BlockBits:]
+	bucket := h.bucketAt(key)
 	// Issue the Phase 2 num[] load early so its (often L3-miss) latency is
 	// hidden by Phase 1. n is held in a register until Phase 2.
 	n := h.num[key]
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h5b7BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b7BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h5b7BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -424,7 +439,7 @@ func (h *h5b7) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b7BlockMask)+uint(key)<<h5b7BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b7BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -447,15 +462,15 @@ func (h *h5b7) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h5b7BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h5b7BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b7BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h5b7BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -544,7 +559,7 @@ func (h *h5b7) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b7BlockMask)+uint(key)<<h5b7BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b7BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -889,18 +904,18 @@ func (h *h5b7) findLongestMatchNoWrap(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h5b7BlockBits:]
+	bucket := h.bucketAt(key)
 	// Issue the Phase 2 num[] load early so its (often L3-miss) latency is
 	// hidden by Phase 1.
 	n := h.num[key]
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, cur+1)
-	nextBase := uint(nextKey) << h5b7BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h5b7BlockMask)])
+		p := uint(nextBucket[(nextN-1)&h5b7BlockMask])
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -1156,7 +1171,7 @@ func (h *h5b7) findLongestMatchNoWrap(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h5b7BlockMask)+uint(key)<<h5b7BlockBits] = uint32(cur)
+	bucket[h.num[key]&h5b7BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash6b5.go
+++ b/internal/encoder/hash6b5.go
@@ -7,7 +7,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // H6b5 configuration constants for quality 6.
 const (
@@ -46,6 +50,17 @@ type h6b5 struct {
 }
 
 func (h *h6b5) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h6b5BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h6b5HashShift, so key is always <
+// h6b5BucketSize and key<<h6b5BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h6b5BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h6b5) bucketAt(key uint32) *[h6b5BlockSize]uint32 {
+	return (*[h6b5BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h6b5BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 8 bytes at data[i:i+8].
 func (h *h6b5) hash(data []byte, i uint) uint32 {
@@ -147,15 +162,15 @@ func (h *h6b5) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b5BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b5BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b5BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -290,7 +305,7 @@ func (h *h6b5) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b5BlockMask)+uint(key)<<h6b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -313,15 +328,15 @@ func (h *h6b5) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b5BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b5BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b5BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -408,7 +423,7 @@ func (h *h6b5) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b5BlockMask)+uint(key)<<h6b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -703,15 +718,15 @@ func (h *h6b5) findLongestMatchNoWrap(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h6b5BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, cur+1)
-	nextBase := uint(nextKey) << h6b5BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b5BlockMask)])
+		p := uint(nextBucket[(nextN-1)&h6b5BlockMask])
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -840,7 +855,7 @@ func (h *h6b5) findLongestMatchNoWrap(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b5BlockMask)+uint(key)<<h6b5BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b5BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash6b6.go
+++ b/internal/encoder/hash6b6.go
@@ -8,7 +8,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h6b6 configuration constants for quality 7.
 const (
@@ -42,6 +46,17 @@ type h6b6 struct {
 }
 
 func (h *h6b6) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h6b6BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h6b6HashShift, so key is always <
+// h6b6BucketSize and key<<h6b6BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h6b6BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h6b6) bucketAt(key uint32) *[h6b6BlockSize]uint32 {
+	return (*[h6b6BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h6b6BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 8 bytes at data[i:i+8].
 func (h *h6b6) hash(data []byte, i uint) uint32 {
@@ -124,15 +139,15 @@ func (h *h6b6) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b6BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b6BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b6BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b6BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -261,7 +276,7 @@ func (h *h6b6) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b6BlockMask)+uint(key)<<h6b6BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b6BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -284,15 +299,15 @@ func (h *h6b6) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b6BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b6BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b6BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b6BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -426,7 +441,7 @@ func (h *h6b6) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b6BlockMask)+uint(key)<<h6b6BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b6BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash6b7.go
+++ b/internal/encoder/hash6b7.go
@@ -8,7 +8,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h6b7 configuration constants for quality 8.
 const (
@@ -42,6 +46,17 @@ type h6b7 struct {
 }
 
 func (h *h6b7) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h6b7BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h6b7HashShift, so key is always <
+// h6b7BucketSize and key<<h6b7BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h6b7BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h6b7) bucketAt(key uint32) *[h6b7BlockSize]uint32 {
+	return (*[h6b7BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h6b7BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 8 bytes at data[i:i+8].
 func (h *h6b7) hash(data []byte, i uint) uint32 {
@@ -134,15 +149,15 @@ func (h *h6b7) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b7BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b7BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b7BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b7BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -267,7 +282,7 @@ func (h *h6b7) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b7BlockMask)+uint(key)<<h6b7BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b7BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -290,15 +305,15 @@ func (h *h6b7) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b7BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b7BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b7BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b7BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -423,7 +438,7 @@ func (h *h6b7) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b7BlockMask)+uint(key)<<h6b7BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b7BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.

--- a/internal/encoder/hash6b8.go
+++ b/internal/encoder/hash6b8.go
@@ -8,7 +8,11 @@
 
 package encoder
 
-import "github.com/molecule-man/go-brrr/internal/core"
+import (
+	"unsafe"
+
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // h6b8 configuration constants for quality 9.
 const (
@@ -47,6 +51,17 @@ type h6b8 struct {
 }
 
 func (h *h6b8) common() *hasherCommon { return &h.hasherCommon }
+
+// bucketAt returns a pointer to the h6b8BlockSize-entry ring buffer for key.
+//
+// hash() shifts its product right by h6b8HashShift, so key is always <
+// h6b8BucketSize and key<<h6b8BlockBits addresses a whole block inside buckets.
+// Handing the scan loops a fixed-size array pointer instead of a slice lets
+// the compiler prove `i & h6b8BlockMask` is in range, dropping a bounds check
+// from every probe iteration of the match search.
+func (h *h6b8) bucketAt(key uint32) *[h6b8BlockSize]uint32 {
+	return (*[h6b8BlockSize]uint32)(unsafe.Add(unsafe.Pointer(&h.buckets), uintptr(key)<<(h6b8BlockBits+2)))
+}
 
 // hash computes a 15-bit bucket index from 8 bytes at data[i:i+8].
 func (h *h6b8) hash(data []byte, i uint) uint32 {
@@ -144,15 +159,15 @@ func (h *h6b8) findLongestMatch(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b8BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b8BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b8BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b8BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -537,7 +552,7 @@ func (h *h6b8) findLongestMatch(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b8BlockMask)+uint(key)<<h6b8BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b8BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -560,15 +575,15 @@ func (h *h6b8) findLongestMatchSmallBuf(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, curMasked)
-	bucket := h.buckets[uint(key)<<h6b8BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, (cur+1)&ringBufferMask)
-	nextBase := uint(nextKey) << h6b8BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b8BlockMask)]) & ringBufferMask
+		p := uint(nextBucket[(nextN-1)&h6b8BlockMask]) & ringBufferMask
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -700,7 +715,7 @@ func (h *h6b8) findLongestMatchSmallBuf(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b8BlockMask)+uint(key)<<h6b8BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b8BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.
@@ -1017,15 +1032,15 @@ func (h *h6b8) findLongestMatchNoWrap(
 	bestScore := out.score
 	bestLen := out.len
 	key := h.hash(data, cur)
-	bucket := h.buckets[uint(key)<<h6b8BlockBits:]
+	bucket := h.bucketAt(key)
 
 	// Speculatively load from the next position's bucket to warm the cache.
 	nextKey := h.hash(data, cur+1)
-	nextBase := uint(nextKey) << h6b8BlockBits
+	nextBucket := h.bucketAt(nextKey)
 	nextN := h.num[nextKey]
-	h.nextBucket = h.buckets[nextBase]
+	h.nextBucket = nextBucket[0]
 	if nextN > 0 {
-		p := uint(h.buckets[nextBase+uint((nextN-1)&h6b8BlockMask)])
+		p := uint(nextBucket[(nextN-1)&h6b8BlockMask])
 		h.nextBucket = uint32(data[p])
 	}
 
@@ -1400,7 +1415,7 @@ func (h *h6b8) findLongestMatchNoWrap(
 	}
 
 	// Store current position in the bucket.
-	h.buckets[uint(h.num[key]&h6b8BlockMask)+uint(key)<<h6b8BlockBits] = uint32(cur)
+	bucket[h.num[key]&h6b8BlockMask] = uint32(cur)
 	h.num[key]++
 
 	// Phase 3: static dictionary fallback when no hash match was found.


### PR DESCRIPTION
Address each hash bucket through a *[blockSize]uint32 (bucketAt) instead of a slice, so the compiler can prove `i & blockMask` is in range and drop a bounds check from every probe iteration of the match search. h5's small contiguous path also answers the first eight bytes of a surviving candidate inline before falling back to the SSE2 match-length call.

Caveat: I had Fable 5.1 do this work on an older Xeon where using the benchmarks it saw ~+8 to +17% uplift across q5 to q9. I would expect this type of bounds-elimination optimization to be helpful generally, but performance is sometimes surprising.