### PR TITLE
perf(q7-q8): unroll the h41 distance-cache phase 1

### DIFF
--- a/internal/encoder/hash41.go
+++ b/internal/encoder/hash41.go
@@ -148,11 +148,113 @@ func (h *h41) findLongestMatch(
 	out.len = 0
 	out.lenCodeDelta = 0
 
-	// Phase 1: try cached distances.
-	for i := range uint(h41NumLastDistances) {
+	// Phase 1: try cached distances. The first cache entry is hot and does
+	// not need the tinyHash rejection used by the other entries.
+	{
+		backward := uint(distCache[0])
+		prevIx := cur - backward
+		if prevIx < cur && backward <= maxBackward {
+			prevIx &= ringBufferMask
+			if loadByte(data, prevIx) == loadByte(data, curMasked) &&
+				loadByte(data, prevIx+1) == loadByte(data, curMasked+1) {
+				ml := uint(matchLenAtNoInline(data, prevIx, curMasked, int(maxLength)))
+				if ml >= 2 {
+					score := backwardReferenceScoreUsingLastDistance(ml)
+					if bestScore < score {
+						bestScore = score
+						bestLen = ml
+						out.len = bestLen
+						out.distance = backward
+						out.score = bestScore
+					}
+				}
+			}
+		}
+	}
+
+	{
+		backward := uint(distCache[1])
+		prevIx := cur - backward
+		if h.tinyHash[uint16(prevIx)] == tinyHash {
+			if prevIx < cur && backward <= maxBackward {
+				prevIx &= ringBufferMask
+				if loadByte(data, prevIx) == loadByte(data, curMasked) &&
+					loadByte(data, prevIx+1) == loadByte(data, curMasked+1) {
+					ml := uint(matchLenAtNoInline(data, prevIx, curMasked, int(maxLength)))
+					if ml >= 2 {
+						score := backwardReferenceScoreUsingLastDistance(ml)
+						if bestScore < score {
+							score -= backwardReferencePenaltyUsingLastDistance(1)
+							if bestScore < score {
+								bestScore = score
+								bestLen = ml
+								out.len = bestLen
+								out.distance = backward
+								out.score = bestScore
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	{
+		backward := uint(distCache[2])
+		prevIx := cur - backward
+		if h.tinyHash[uint16(prevIx)] == tinyHash {
+			if prevIx < cur && backward <= maxBackward {
+				prevIx &= ringBufferMask
+				if loadByte(data, prevIx) == loadByte(data, curMasked) &&
+					loadByte(data, prevIx+1) == loadByte(data, curMasked+1) {
+					ml := uint(matchLenAtNoInline(data, prevIx, curMasked, int(maxLength)))
+					if ml >= 2 {
+						score := backwardReferenceScoreUsingLastDistance(ml)
+						if bestScore < score {
+							score -= backwardReferencePenaltyUsingLastDistance(2)
+							if bestScore < score {
+								bestScore = score
+								bestLen = ml
+								out.len = bestLen
+								out.distance = backward
+								out.score = bestScore
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	{
+		backward := uint(distCache[3])
+		prevIx := cur - backward
+		if h.tinyHash[uint16(prevIx)] == tinyHash {
+			if prevIx < cur && backward <= maxBackward {
+				prevIx &= ringBufferMask
+				if loadByte(data, prevIx) == loadByte(data, curMasked) &&
+					loadByte(data, prevIx+1) == loadByte(data, curMasked+1) {
+					ml := uint(matchLenAtNoInline(data, prevIx, curMasked, int(maxLength)))
+					if ml >= 2 {
+						score := backwardReferenceScoreUsingLastDistance(ml)
+						if bestScore < score {
+							score -= backwardReferencePenaltyUsingLastDistance(3)
+							if bestScore < score {
+								bestScore = score
+								bestLen = ml
+								out.len = bestLen
+								out.distance = backward
+								out.score = bestScore
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for i := uint(4); i < uint(h41NumLastDistances); i++ {
 		backward := uint(distCache[i])
 		prevIx := cur - backward
-		if i > 0 && h.tinyHash[uint16(prevIx)] != tinyHash {
+		if h.tinyHash[uint16(prevIx)] != tinyHash {
 			continue
 		}
 		if prevIx >= cur || backward > maxBackward {
@@ -168,9 +270,7 @@ func (h *h41) findLongestMatch(
 		if ml >= 2 {
 			score := backwardReferenceScoreUsingLastDistance(ml)
 			if bestScore < score {
-				if i != 0 {
-					score -= backwardReferencePenaltyUsingLastDistance(i)
-				}
+				score -= backwardReferencePenaltyUsingLastDistance(i)
 				if bestScore < score {
 					bestScore = score
 					bestLen = ml


### PR DESCRIPTION
| | /tmp/before-fa32.txt (B/s) | /tmp/after-fa32.txt (B/s) | diff | p |
| --- | --- | --- | --- | --- |
| 7 Json_2k | 42.79Mi ± 0% | 45.67Mi ± 0% | +6.73% | 0.000 |
| 7 VariedPayloads | 20.19Mi ± 0% | 21.15Mi ± 0% | +4.77% | 0.000 |
| 7 Large | 16.22Mi ± 0% | 16.94Mi ± 0% | +4.41% | 0.000 |
| 7 corpus_000830kb.so.css | 52.92Mi ± 0% | 55.67Mi ± 0% | +5.19% | 0.000 |
| 7 corpus_005kb.webp.js | 37.76Mi ± 1% | 40.23Mi ± 0% | +6.54% | 0.000 |
| 7 corpus_011kb.quer.json | 108.7Mi ± 1% | 115.9Mi ± 4% | +6.61% | 0.000 |
| 7 corpus_070kb.pdd2.json | 90.98Mi ± 0% | 96.04Mi ± 0% | +5.56% | 0.000 |
| 7 corpus_107kb.pdd1.json | 89.82Mi ± 0% | 94.44Mi ± 0% | +5.15% | 0.000 |
| 7 corpus_137kb.789-.js | 25.66Mi ± 0% | 27.00Mi ± 0% | +5.20% | 0.000 |
| 7 corpus_243kb.6709.js | 26.54Mi ± 0% | 27.90Mi ± 0% | +5.14% | 0.000 |
| 7 corpus_542kb.pdd1.html | 48.21Mi ± 0% | 50.54Mi ± 0% | +4.83% | 0.000 |
| 7 corpus_718kb.pll2.html | 55.49Mi ± 0% | 58.12Mi ± 0% | +4.73% | 0.000 |
| 8 Json_2k | 42.77Mi ± 0% | 45.67Mi ± 0% | +6.78% | 0.000 |
| 8 VariedPayloads | 17.35Mi ± 0% | 18.12Mi ± 0% | +4.45% | 0.000 |
| 8 Large | 13.57Mi ± 0% | 14.16Mi ± 0% | +4.36% | 0.000 |
| 8 corpus_000830kb.so.css | 40.47Mi ± 0% | 42.47Mi ± 0% | +4.92% | 0.000 |
| 8 corpus_005kb.webp.js | 37.80Mi ± 0% | 40.21Mi ± 0% | +6.36% | 0.000 |
| 8 corpus_011kb.quer.json | 108.1Mi ± 3% | 115.6Mi ± 2% | +6.90% | 0.000 |
| 8 corpus_070kb.pdd2.json | 88.07Mi ± 0% | 92.64Mi ± 0% | +5.19% | 0.000 |
| 8 corpus_107kb.pdd1.json | 85.98Mi ± 0% | 90.04Mi ± 0% | +4.71% | 0.000 |
| 8 corpus_137kb.789-.js | 23.05Mi ± 0% | 24.23Mi ± 0% | +5.13% | 0.000 |
| 8 corpus_243kb.6709.js | 24.19Mi ± 0% | 25.39Mi ± 0% | +4.93% | 0.000 |
| 8 corpus_542kb.pdd1.html | 40.37Mi ± 0% | 42.20Mi ± 0% | +4.54% | 0.000 |
| 8 corpus_718kb.pll2.html | 47.54Mi ± 0% | 49.72Mi ± 0% | +4.59% | 0.000 |
| **geomean** | 41.32Mi | 43.51Mi | +5.32% |  |
| **n** | 15 | 15 |


---

| | /tmp/before-fa16.txt (B/s) | /tmp/after-fa16.txt (B/s) | diff | p |
| --- | --- | --- | --- | --- |
| 7 Json_2k | 43.37Mi ± 0% | 45.85Mi ± 0% | +5.72% | 0.000 |
| 7 VariedPayloads | 20.25Mi ± 0% | 21.14Mi ± 0% | +4.43% | 0.000 |
| 7 Large | 16.29Mi ± 0% | 16.98Mi ± 0% | +4.27% | 0.000 |
| 7 corpus_000830kb.so.css | 52.68Mi ± 0% | 55.40Mi ± 0% | +5.16% | 0.000 |
| 7 corpus_005kb.webp.js | 38.69Mi ± 0% | 40.80Mi ± 0% | +5.45% | 0.000 |
| 7 corpus_011kb.quer.json | 111.7Mi ± 0% | 114.7Mi ± 2% | +2.71% | 0.000 |
| 7 corpus_070kb.pdd2.json | 92.00Mi ± 0% | 94.89Mi ± 0% | +3.14% | 0.000 |
| 7 corpus_107kb.pdd1.json | 90.73Mi ± 1% | 93.43Mi ± 0% | +2.97% | 0.000 |
| 7 corpus_137kb.789-.js | 25.70Mi ± 0% | 27.04Mi ± 0% | +5.19% | 0.000 |
| 7 corpus_243kb.6709.js | 26.61Mi ± 0% | 27.95Mi ± 0% | +5.05% | 0.000 |
| 7 corpus_542kb.pdd1.html | 48.35Mi ± 0% | 50.44Mi ± 0% | +4.32% | 0.000 |
| 7 corpus_718kb.pll2.html | 55.66Mi ± 0% | 57.94Mi ± 0% | +4.10% | 0.000 |
| 8 Json_2k | 43.32Mi ± 1% | 45.90Mi ± 0% | +5.97% | 0.000 |
| 8 VariedPayloads | 17.40Mi ± 0% | 18.13Mi ± 0% | +4.16% | 0.000 |
| 8 Large | 13.64Mi ± 0% | 14.17Mi ± 0% | +3.92% | 0.000 |
| 8 corpus_000830kb.so.css | 40.31Mi ± 0% | 42.47Mi ± 0% | +5.35% | 0.000 |
| 8 corpus_005kb.webp.js | 38.68Mi ± 0% | 40.83Mi ± 0% | +5.55% | 0.000 |
| 8 corpus_011kb.quer.json | 111.2Mi ± 0% | 114.6Mi ± 0% | +3.01% | 0.000 |
| 8 corpus_070kb.pdd2.json | 88.57Mi ± 1% | 91.20Mi ± 1% | +2.97% | 0.000 |
| 8 corpus_107kb.pdd1.json | 87.17Mi ± 0% | 89.42Mi ± 0% | +2.58% | 0.000 |
| 8 corpus_137kb.789-.js | 23.12Mi ± 0% | 24.23Mi ± 0% | +4.83% | 0.000 |
| 8 corpus_243kb.6709.js | 24.22Mi ± 0% | 25.43Mi ± 0% | +5.00% | 0.000 |
| 8 corpus_542kb.pdd1.html | 40.42Mi ± 0% | 42.27Mi ± 0% | +4.58% | 0.000 |
| 8 corpus_718kb.pll2.html | 47.53Mi ± 0% | 49.72Mi ± 0% | +4.61% | 0.000 |
| **geomean** | 41.65Mi | 43.47Mi | +4.37% |  |
| **n** | 15 | 15 |



---


| | /tmp/before-fa64.txt (B/s) | /tmp/after-fa64.txt (B/s) | diff | p |
| --- | --- | --- | --- | --- |
| 7 Json_2k | 43.28Mi ± 0% | 45.39Mi ± 1% | +4.87% | 0.000 |
| 7 VariedPayloads | 20.25Mi ± 0% | 21.16Mi ± 0% | +4.52% | 0.000 |
| 7 Large | 16.25Mi ± 0% | 16.97Mi ± 0% | +4.40% | 0.000 |
| 7 corpus_000830kb.so.css | 53.57Mi ± 0% | 55.63Mi ± 0% | +3.85% | 0.000 |
| 7 corpus_005kb.webp.js | 37.22Mi ± 0% | 38.95Mi ± 0% | +4.64% | 0.000 |
| 7 corpus_011kb.quer.json | 111.0Mi ± 0% | 114.8Mi ± 0% | +3.43% | 0.000 |
| 7 corpus_070kb.pdd2.json | 92.91Mi ± 1% | 95.86Mi ± 0% | +3.18% | 0.000 |
| 7 corpus_107kb.pdd1.json | 91.01Mi ± 0% | 94.27Mi ± 0% | +3.58% | 0.000 |
| 7 corpus_137kb.789-.js | 25.80Mi ± 0% | 27.05Mi ± 0% | +4.84% | 0.000 |
| 7 corpus_243kb.6709.js | 26.71Mi ± 0% | 27.92Mi ± 0% | +4.53% | 0.000 |
| 7 corpus_542kb.pdd1.html | 48.55Mi ± 0% | 50.53Mi ± 0% | +4.07% | 0.000 |
| 7 corpus_718kb.pll2.html | 55.72Mi ± 0% | 58.18Mi ± 0% | +4.42% | 0.000 |
| 8 Json_2k | 43.27Mi ± 2% | 45.36Mi ± 0% | +4.83% | 0.000 |
| 8 VariedPayloads | 17.40Mi ± 0% | 18.10Mi ± 0% | +4.00% | 0.000 |
| 8 Large | 13.61Mi ± 0% | 14.18Mi ± 0% | +4.20% | 0.000 |
| 8 corpus_000830kb.so.css | 40.82Mi ± 0% | 42.52Mi ± 0% | +4.18% | 0.000 |
| 8 corpus_005kb.webp.js | 37.23Mi ± 0% | 38.96Mi ± 0% | +4.64% | 0.000 |
| 8 corpus_011kb.quer.json | 110.3Mi ± 0% | 114.3Mi ± 0% | +3.63% | 0.000 |
| 8 corpus_070kb.pdd2.json | 89.39Mi ± 0% | 92.76Mi ± 0% | +3.78% | 0.000 |
| 8 corpus_107kb.pdd1.json | 87.25Mi ± 0% | 89.89Mi ± 1% | +3.03% | 0.000 |
| 8 corpus_137kb.789-.js | 23.16Mi ± 0% | 24.23Mi ± 0% | +4.61% | 0.000 |
| 8 corpus_243kb.6709.js | 24.28Mi ± 0% | 25.42Mi ± 0% | +4.67% | 0.000 |
| 8 corpus_542kb.pdd1.html | 40.57Mi ± 0% | 42.30Mi ± 0% | +4.25% | 0.000 |
| 8 corpus_718kb.pll2.html | 47.75Mi ± 0% | 49.61Mi ± 0% | +3.89% | 0.000 |
| **geomean** | 41.61Mi | 43.34Mi | +4.17% |  |
| **n** | 15 | 15 |
