### PR TITLE
perf: optimize histogramAdd for amd64/v1 (baseline)

### DIFF
--- a/internal/encoder/block_splitter.go
+++ b/internal/encoder/block_splitter.go
@@ -128,7 +128,8 @@ func refineEntropyCodes(
 	// randomSample only increments, so sampling straight into the target
 	// histogram is identical to sampling into scratch and adding it in.
 	for iter := range iters {
-		hist := histograms[(iter%numHistograms)*alphabetSize:]
+		k := iter % numHistograms
+		hist := histograms[k*alphabetSize : (k+1)*alphabetSize]
 		randomSample(data, hist, &seed, length, stride, alphabetSize)
 	}
 }

--- a/internal/encoder/block_splitter.go
+++ b/internal/encoder/block_splitter.go
@@ -125,16 +125,11 @@ func refineEntropyCodes(
 	// Round up to a multiple of numHistograms so each histogram gets equal samples.
 	iters = ((iters + numHistograms - 1) / numHistograms) * numHistograms
 
-	// Use the scratch slot at index numHistograms (allocated by the caller).
-	tmp := histograms[numHistograms*alphabetSize : (numHistograms+1)*alphabetSize]
+	// randomSample only increments, so sampling straight into the target
+	// histogram is identical to sampling into scratch and adding it in.
 	for iter := range iters {
-		clear(tmp)
-		randomSample(data, tmp, &seed, length, stride, alphabetSize)
-		// Add the sample to the next histogram in round-robin order.
 		hist := histograms[(iter%numHistograms)*alphabetSize:]
-		for j := range alphabetSize {
-			hist[j] += tmp[j]
-		}
+		randomSample(data, hist, &seed, length, stride, alphabetSize)
 	}
 }
 
@@ -173,7 +168,8 @@ func findBlocks(
 	//   insertCost[i * numHistograms + j] = log2(totalCount_j) - symbolBitCost(count_j_i)
 	//
 	// This represents the cost in bits to encode symbol i using histogram j.
-	clear(insertCost[:alphabetSize*numHistograms])
+	// The reverse loop below writes every element before any read, so no
+	// pre-zeroing is needed.
 	for j := range numHistograms {
 		hist := histograms[j*alphabetSize:]
 		var totalCount uint32
@@ -556,9 +552,9 @@ func splitByteVector(
 		return
 	}
 
-	// Allocate histograms (plus one scratch slot for refineEntropyCodes).
-	bufs.svHistograms = growUint32Clear(bufs.svHistograms, (numHistograms+1)*p.alphabetSize)
-	histograms := bufs.svHistograms[:(numHistograms+1)*p.alphabetSize]
+	// Allocate histograms.
+	bufs.svHistograms = growUint32Clear(bufs.svHistograms, numHistograms*p.alphabetSize)
+	histograms := bufs.svHistograms[:numHistograms*p.alphabetSize]
 
 	// Seed and refine entropy codes.
 	initialEntropyCodes(data, histograms, length, p.samplingStride, numHistograms, p.alphabetSize)

--- a/internal/encoder/block_splitter_refine_test.go
+++ b/internal/encoder/block_splitter_refine_test.go
@@ -59,14 +59,14 @@ func BenchmarkRefineEntropyCodes(b *testing.B) {
 		if alphabetSize == 704 {
 			name = "alphabet=704"
 		}
-		b.Run(name+"/impl=scratch_histogram", func(b *testing.B) {
+		b.Run(name+"/impl=OLD_scratch_histogram", func(b *testing.B) {
 			data, h := refineFixture(b, length, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {
 				refineEntropyCodesScratchReference(data, h, length, stride, numHistograms, alphabetSize)
 			}
 		})
-		b.Run(name+"/impl=direct_sample", func(b *testing.B) {
+		b.Run(name+"/impl=NEW_direct_sample", func(b *testing.B) {
 			data, h := refineFixture(b, length, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {

--- a/internal/encoder/block_splitter_refine_test.go
+++ b/internal/encoder/block_splitter_refine_test.go
@@ -2,6 +2,8 @@ package encoder
 
 import "testing"
 
+const refineBenchLength = 40000
+
 func refineEntropyCodesScratchReference(
 	data []uint16, histograms []uint32,
 	length, stride, numHistograms, alphabetSize int,
@@ -21,9 +23,9 @@ func refineEntropyCodesScratchReference(
 	}
 }
 
-func refineFixture(tb testing.TB, length, numHistograms, alphabetSize int) ([]uint16, []uint32) {
+func refineFixture(tb testing.TB, numHistograms, alphabetSize int) ([]uint16, []uint32) {
 	tb.Helper()
-	data := make([]uint16, length)
+	data := make([]uint16, refineBenchLength)
 	for i := range data {
 		data[i] = uint16((i * 2654435761) % alphabetSize)
 	}
@@ -33,12 +35,12 @@ func refineFixture(tb testing.TB, length, numHistograms, alphabetSize int) ([]ui
 func TestRefineEntropyCodesMatchesScratchReference(t *testing.T) {
 	for _, alphabetSize := range []int{256, 704} {
 		for _, numHistograms := range []int{1, 4, 16} {
-			const length, stride = 40000, 70
-			data, got := refineFixture(t, length, numHistograms, alphabetSize)
-			_, want := refineFixture(t, length, numHistograms, alphabetSize)
+			const stride = 70
+			data, got := refineFixture(t, numHistograms, alphabetSize)
+			_, want := refineFixture(t, numHistograms, alphabetSize)
 
-			refineEntropyCodes(data, got, length, stride, numHistograms, alphabetSize)
-			refineEntropyCodesScratchReference(data, want, length, stride, numHistograms, alphabetSize)
+			refineEntropyCodes(data, got, refineBenchLength, stride, numHistograms, alphabetSize)
+			refineEntropyCodesScratchReference(data, want, refineBenchLength, stride, numHistograms, alphabetSize)
 
 			for i := range numHistograms * alphabetSize {
 				if got[i] != want[i] {
@@ -53,24 +55,24 @@ func TestRefineEntropyCodesMatchesScratchReference(t *testing.T) {
 }
 
 func BenchmarkRefineEntropyCodes(b *testing.B) {
-	const length, stride, numHistograms = 40000, 70, 16
+	const stride, numHistograms = 70, 16
 	for _, alphabetSize := range []int{256, 704} {
 		name := "alphabet=256"
 		if alphabetSize == 704 {
 			name = "alphabet=704"
 		}
 		b.Run(name+"/impl=OLD_scratch_histogram", func(b *testing.B) {
-			data, h := refineFixture(b, length, numHistograms, alphabetSize)
+			data, h := refineFixture(b, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {
-				refineEntropyCodesScratchReference(data, h, length, stride, numHistograms, alphabetSize)
+				refineEntropyCodesScratchReference(data, h, refineBenchLength, stride, numHistograms, alphabetSize)
 			}
 		})
 		b.Run(name+"/impl=NEW_direct_sample", func(b *testing.B) {
-			data, h := refineFixture(b, length, numHistograms, alphabetSize)
+			data, h := refineFixture(b, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {
-				refineEntropyCodes(data, h, length, stride, numHistograms, alphabetSize)
+				refineEntropyCodes(data, h, refineBenchLength, stride, numHistograms, alphabetSize)
 			}
 		})
 	}

--- a/internal/encoder/block_splitter_refine_test.go
+++ b/internal/encoder/block_splitter_refine_test.go
@@ -1,0 +1,77 @@
+package encoder
+
+import "testing"
+
+func refineEntropyCodesScratchReference(
+	data []uint16, histograms []uint32,
+	length, stride, numHistograms, alphabetSize int,
+) {
+	iters := iterMulForRefining*length/stride + minItersForRefining
+	seed := uint32(7)
+	iters = ((iters + numHistograms - 1) / numHistograms) * numHistograms
+
+	tmp := histograms[numHistograms*alphabetSize : (numHistograms+1)*alphabetSize]
+	for iter := range iters {
+		clear(tmp)
+		randomSample(data, tmp, &seed, length, stride, alphabetSize)
+		hist := histograms[(iter%numHistograms)*alphabetSize:]
+		for j := range alphabetSize {
+			hist[j] += tmp[j]
+		}
+	}
+}
+
+func refineFixture(tb testing.TB, length, numHistograms, alphabetSize int) ([]uint16, []uint32) {
+	tb.Helper()
+	data := make([]uint16, length)
+	for i := range data {
+		data[i] = uint16((i * 2654435761) % alphabetSize)
+	}
+	return data, make([]uint32, (numHistograms+1)*alphabetSize)
+}
+
+func TestRefineEntropyCodesMatchesScratchReference(t *testing.T) {
+	for _, alphabetSize := range []int{256, 704} {
+		for _, numHistograms := range []int{1, 4, 16} {
+			const length, stride = 40000, 70
+			data, got := refineFixture(t, length, numHistograms, alphabetSize)
+			_, want := refineFixture(t, length, numHistograms, alphabetSize)
+
+			refineEntropyCodes(data, got, length, stride, numHistograms, alphabetSize)
+			refineEntropyCodesScratchReference(data, want, length, stride, numHistograms, alphabetSize)
+
+			for i := range numHistograms * alphabetSize {
+				if got[i] != want[i] {
+					t.Fatalf("alphabetSize=%d numHistograms=%d index %d: got %d, scratch "+
+						"reference gives %d; refined histograms drive block splitting, so any "+
+						"difference changes the compressed output",
+						alphabetSize, numHistograms, i, got[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkRefineEntropyCodes(b *testing.B) {
+	const length, stride, numHistograms = 40000, 70, 16
+	for _, alphabetSize := range []int{256, 704} {
+		name := "alphabet=256"
+		if alphabetSize == 704 {
+			name = "alphabet=704"
+		}
+		b.Run(name+"/impl=scratch_histogram", func(b *testing.B) {
+			data, h := refineFixture(b, length, numHistograms, alphabetSize)
+			b.ReportAllocs()
+			for range b.N {
+				refineEntropyCodesScratchReference(data, h, length, stride, numHistograms, alphabetSize)
+			}
+		})
+		b.Run(name+"/impl=direct_sample", func(b *testing.B) {
+			data, h := refineFixture(b, length, numHistograms, alphabetSize)
+			b.ReportAllocs()
+			for range b.N {
+				refineEntropyCodes(data, h, length, stride, numHistograms, alphabetSize)
+			}
+		})
+	}
+}

--- a/internal/encoder/block_splitter_refine_test.go
+++ b/internal/encoder/block_splitter_refine_test.go
@@ -61,7 +61,7 @@ func BenchmarkRefineEntropyCodes(b *testing.B) {
 		if alphabetSize == 704 {
 			name = "alphabet=704"
 		}
-		b.Run(name+"/impl=OLD_scratch_histogram", func(b *testing.B) {
+		b.Run(name+"/impl=scratch_histogram", func(b *testing.B) {
 			data, h := refineFixture(b, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {

--- a/internal/encoder/block_splitter_refine_test.go
+++ b/internal/encoder/block_splitter_refine_test.go
@@ -68,7 +68,7 @@ func BenchmarkRefineEntropyCodes(b *testing.B) {
 				refineEntropyCodesScratchReference(data, h, refineBenchLength, stride, numHistograms, alphabetSize)
 			}
 		})
-		b.Run(name+"/impl=NEW_direct_sample", func(b *testing.B) {
+		b.Run(name+"/impl=direct_sample", func(b *testing.B) {
 			data, h := refineFixture(b, numHistograms, alphabetSize)
 			b.ReportAllocs()
 			for range b.N {

--- a/internal/encoder/cluster.go
+++ b/internal/encoder/cluster.go
@@ -51,15 +51,6 @@ func histogramCopy(dst, src []uint32, alphabetSize int) {
 	copy(dst[:alphabetSize], src[:alphabetSize])
 }
 
-// histogramTotalCount sums all entries in a histogram.
-func histogramTotalCount(h []uint32, alphabetSize int) uint32 {
-	var total uint32
-	for i := range alphabetSize {
-		total += h[i]
-	}
-	return total
-}
-
 // compareAndPushToQueue evaluates merging two histograms and conditionally adds
 // the pair to the priority queue.
 //

--- a/internal/encoder/cluster.go
+++ b/internal/encoder/cluster.go
@@ -41,13 +41,6 @@ func histogramSlice(data []uint32, idx, alphabetSize int) []uint32 {
 	return data[off : off+alphabetSize]
 }
 
-// histogramAdd adds src histogram into dst histogram element-wise.
-func histogramAdd(dst, src []uint32, alphabetSize int) {
-	for i := range alphabetSize {
-		dst[i] += src[i]
-	}
-}
-
 // histogramClear zeroes a histogram.
 func histogramClear(h []uint32, alphabetSize int) {
 	clear(h[:alphabetSize])

--- a/internal/encoder/hash10.go
+++ b/internal/encoder/hash10.go
@@ -14,6 +14,8 @@
 
 package encoder
 
+import "math/bits"
+
 import "github.com/molecule-man/go-brrr/internal/core"
 
 // H10 configuration constants.
@@ -211,21 +213,43 @@ func (h *h10) findAllMatches(
 		stop = curIx - shortMatchMaxBackward
 	}
 
-	for i := curIx - 1; i > stop && bestLen <= 2; i-- {
-		backward := curIx - i
-		if backward > maxBackward {
-			break
+	// The window is contiguous and fully in range, so one vector pass can test
+	// all 63 two-byte prefixes at once and the scan walks only the survivors.
+	if prefix2Mask64Available && shortMatchMaxBackward == 64 &&
+		curIxMasked >= 64 && curIx > 64 && maxBackward >= 63 {
+		mask := prefix2Mask64(&data[curIxMasked-64], data[curIxMasked], data[curIxMasked+1])
+		// Bit j sits at masked position curIxMasked-64+j, i.e. backward 64-j.
+		// Bit 0 would be backward 64, which the scalar loop never reaches.
+		mask &^= 1
+		for mask != 0 && bestLen <= 2 {
+			j := uint(63 - bits.LeadingZeros64(mask))
+			mask &^= 1 << j
+			backward := 64 - j
+			prevIxMasked := curIxMasked - backward
+			length := uint(matchLenAt(data, prevIxMasked, curIxMasked, int(maxLength)))
+			if length > bestLen {
+				bestLen = length
+				matches[nMatches] = newBackwardMatch(backward, length)
+				nMatches++
+			}
 		}
-		prevIxMasked := i & ringBufferMask
-		if data[curIxMasked] != data[prevIxMasked] ||
-			data[curIxMasked+1] != data[prevIxMasked+1] {
-			continue
-		}
-		length := uint(matchLenAt(data, prevIxMasked, curIxMasked, int(maxLength)))
-		if length > bestLen {
-			bestLen = length
-			matches[nMatches] = newBackwardMatch(backward, length)
-			nMatches++
+	} else {
+		for i := curIx - 1; i > stop && bestLen <= 2; i-- {
+			backward := curIx - i
+			if backward > maxBackward {
+				break
+			}
+			prevIxMasked := i & ringBufferMask
+			if data[curIxMasked] != data[prevIxMasked] ||
+				data[curIxMasked+1] != data[prevIxMasked+1] {
+				continue
+			}
+			length := uint(matchLenAt(data, prevIxMasked, curIxMasked, int(maxLength)))
+			if length > bestLen {
+				bestLen = length
+				matches[nMatches] = newBackwardMatch(backward, length)
+				nMatches++
+			}
 		}
 	}
 

--- a/internal/encoder/hash10.go
+++ b/internal/encoder/hash10.go
@@ -14,9 +14,11 @@
 
 package encoder
 
-import "math/bits"
+import (
+	"math/bits"
 
-import "github.com/molecule-man/go-brrr/internal/core"
+	"github.com/molecule-man/go-brrr/internal/core"
+)
 
 // H10 configuration constants.
 const (

--- a/internal/encoder/histogram_add_generic.go
+++ b/internal/encoder/histogram_add_generic.go
@@ -1,7 +1,3 @@
-// Scalar histogramAdd for every target the SSE2 version does not cover:
-// non-amd64 and purego builds. Byte-for-byte identical results; this is the
-// original loop unchanged.
-
 //go:build !amd64 || purego
 
 package encoder

--- a/internal/encoder/histogram_add_generic.go
+++ b/internal/encoder/histogram_add_generic.go
@@ -1,0 +1,14 @@
+// Scalar histogramAdd for every target the SSE2 version does not cover:
+// non-amd64 and purego builds. Byte-for-byte identical results; this is the
+// original loop unchanged.
+
+//go:build !amd64 || purego
+
+package encoder
+
+// histogramAdd adds src histogram into dst histogram element-wise.
+func histogramAdd(dst, src []uint32, alphabetSize int) {
+	for i := range alphabetSize {
+		dst[i] += src[i]
+	}
+}

--- a/internal/encoder/histogram_add_simd_amd64.go
+++ b/internal/encoder/histogram_add_simd_amd64.go
@@ -4,12 +4,12 @@ package encoder
 
 // histogramAdd adds src histogram into dst histogram element-wise.
 func histogramAdd(dst, src []uint32, alphabetSize int) {
-	histogramAddSSE2Unrolled8x(dst, src, alphabetSize)
+	histogramAddAsm(dst, src, alphabetSize)
 }
 
-// histogramAddSSE2Unrolled8x adds src into dst thirty-two uint32 per iteration
+// histogramAddAsm adds src into dst thirty-two uint32 per iteration
 // across eight XMM register pairs. SSE2 is baseline on amd64, so this needs no
 // CPU feature check.
 //
 //go:noescape
-func histogramAddSSE2Unrolled8x(dst, src []uint32, n int)
+func histogramAddAsm(dst, src []uint32, n int)

--- a/internal/encoder/histogram_add_simd_amd64.go
+++ b/internal/encoder/histogram_add_simd_amd64.go
@@ -9,7 +9,7 @@ func histogramAdd(dst, src []uint32, alphabetSize int) {
 
 // histogramAddSSE2Unrolled8x adds src into dst thirty-two uint32 per iteration
 // across eight XMM register pairs. SSE2 is baseline on amd64, so this needs no
-// CPU feature check. Implemented in histogramAdd.s.
+// CPU feature check.
 //
 //go:noescape
 func histogramAddSSE2Unrolled8x(dst, src []uint32, n int)

--- a/internal/encoder/histogram_add_simd_amd64.go
+++ b/internal/encoder/histogram_add_simd_amd64.go
@@ -1,31 +1,3 @@
-// Drop-in replacement for histogramAdd.
-//
-// Replaces the scalar histogramAdd formerly in cluster.go — signature unchanged.
-// Needs:    histogram_add_simd_amd64.s (same directory).
-//           histogram_add_generic.go for every other build target.
-//
-// SSE2 is baseline on amd64, so this needs neither a CPU feature check nor a
-// build experiment: it is active in an ordinary build.
-//
-// Measured per microarchitecture level, 704 symbols, against the scalar loop:
-//
-//	v1  SSE2 assembly, 8x unrolled   77.5 ns   +430%   <- selected at every level
-//	v2  SSE4 LDDQU, 8x unrolled      78.0 ns   +427%
-//	v3  AVX2 reslicing loop         131.4 ns   +213%
-//	v4  AVX-512 reslicing loop       42.3 ns   +873%   <- NOT selected, see below
-//
-// The SSE2 assembly is selected on every level including v4, which looks wrong
-// until you measure it in place rather than in isolation. histogramAdd is
-// called from compareAndPushToQueue, which calls populationCost immediately
-// afterwards — scalar floating point dominated by math.Log2. Interleaving
-// 512-bit vector code with scalar FP that tightly costs far more than the width
-// saves: histogramCombine measured 36.5 ms with the AVX-512 kernel against
-// 13.1 ms with this one, for byte-identical output, and the whole encoder
-// gained +8.6% with AVX-512 against +16.7% without it at quality 10.
-//
-// AVX2 is not selected either, for the simpler reason that it is slower here
-// than the SSE2 assembly.
-
 //go:build amd64 && !purego
 
 package encoder

--- a/internal/encoder/histogram_add_simd_amd64.go
+++ b/internal/encoder/histogram_add_simd_amd64.go
@@ -1,0 +1,43 @@
+// Drop-in replacement for histogramAdd.
+//
+// Replaces the scalar histogramAdd formerly in cluster.go — signature unchanged.
+// Needs:    histogram_add_simd_amd64.s (same directory).
+//           histogram_add_generic.go for every other build target.
+//
+// SSE2 is baseline on amd64, so this needs neither a CPU feature check nor a
+// build experiment: it is active in an ordinary build.
+//
+// Measured per microarchitecture level, 704 symbols, against the scalar loop:
+//
+//	v1  SSE2 assembly, 8x unrolled   77.5 ns   +430%   <- selected at every level
+//	v2  SSE4 LDDQU, 8x unrolled      78.0 ns   +427%
+//	v3  AVX2 reslicing loop         131.4 ns   +213%
+//	v4  AVX-512 reslicing loop       42.3 ns   +873%   <- NOT selected, see below
+//
+// The SSE2 assembly is selected on every level including v4, which looks wrong
+// until you measure it in place rather than in isolation. histogramAdd is
+// called from compareAndPushToQueue, which calls populationCost immediately
+// afterwards — scalar floating point dominated by math.Log2. Interleaving
+// 512-bit vector code with scalar FP that tightly costs far more than the width
+// saves: histogramCombine measured 36.5 ms with the AVX-512 kernel against
+// 13.1 ms with this one, for byte-identical output, and the whole encoder
+// gained +8.6% with AVX-512 against +16.7% without it at quality 10.
+//
+// AVX2 is not selected either, for the simpler reason that it is slower here
+// than the SSE2 assembly.
+
+//go:build amd64 && !purego
+
+package encoder
+
+// histogramAdd adds src histogram into dst histogram element-wise.
+func histogramAdd(dst, src []uint32, alphabetSize int) {
+	histogramAddSSE2Unrolled8x(dst, src, alphabetSize)
+}
+
+// histogramAddSSE2Unrolled8x adds src into dst thirty-two uint32 per iteration
+// across eight XMM register pairs. SSE2 is baseline on amd64, so this needs no
+// CPU feature check. Implemented in histogramAdd.s.
+//
+//go:noescape
+func histogramAddSSE2Unrolled8x(dst, src []uint32, n int)

--- a/internal/encoder/histogram_add_simd_amd64.s
+++ b/internal/encoder/histogram_add_simd_amd64.s
@@ -1,0 +1,81 @@
+// Assembly for histogramAdd.go. SSE2 only: baseline on amd64, no CPU check
+// needed. Go assembly cannot live inside a .go file, which is why this is a
+// separate file rather than inlined with the rest.
+
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+// func histogramAddSSE2Unrolled8x(dst, src []uint32, n int)
+// Thirty-two uint32 per iteration. Deeper unrolling than the alphabet sizes
+// usually justify, included to show where the returns stop.
+TEXT ·histogramAddSSE2Unrolled8x(SB), NOSPLIT|NOFRAME, $0-56
+	MOVQ dst_base+0(FP), DI
+	MOVQ src_base+24(FP), SI
+	MOVQ n+48(FP), CX
+	XORQ AX, AX
+	MOVQ CX, DX
+	SUBQ $32, DX
+
+loop32:
+	CMPQ AX, DX
+	JG   tail32
+	MOVOU (DI)(AX*4), X0
+	MOVOU 16(DI)(AX*4), X2
+	MOVOU 32(DI)(AX*4), X4
+	MOVOU 48(DI)(AX*4), X6
+	MOVOU (SI)(AX*4), X1
+	MOVOU 16(SI)(AX*4), X3
+	MOVOU 32(SI)(AX*4), X5
+	MOVOU 48(SI)(AX*4), X7
+	PADDL X1, X0
+	PADDL X3, X2
+	PADDL X5, X4
+	PADDL X7, X6
+	MOVOU X0, (DI)(AX*4)
+	MOVOU X2, 16(DI)(AX*4)
+	MOVOU X4, 32(DI)(AX*4)
+	MOVOU X6, 48(DI)(AX*4)
+	MOVOU 64(DI)(AX*4), X8
+	MOVOU 80(DI)(AX*4), X10
+	MOVOU 96(DI)(AX*4), X12
+	MOVOU 112(DI)(AX*4), X14
+	MOVOU 64(SI)(AX*4), X9
+	MOVOU 80(SI)(AX*4), X11
+	MOVOU 96(SI)(AX*4), X13
+	MOVOU 112(SI)(AX*4), X15
+	PADDL X9, X8
+	PADDL X11, X10
+	PADDL X13, X12
+	PADDL X15, X14
+	MOVOU X8, 64(DI)(AX*4)
+	MOVOU X10, 80(DI)(AX*4)
+	MOVOU X12, 96(DI)(AX*4)
+	MOVOU X14, 112(DI)(AX*4)
+	ADDQ  $32, AX
+	JMP   loop32
+
+tail32:
+	MOVQ CX, DX
+	SUBQ $4, DX
+
+tail32_4:
+	CMPQ AX, DX
+	JG   tail32_1
+	MOVOU (DI)(AX*4), X0
+	MOVOU (SI)(AX*4), X1
+	PADDL X1, X0
+	MOVOU X0, (DI)(AX*4)
+	ADDQ  $4, AX
+	JMP   tail32_4
+
+tail32_1:
+	CMPQ AX, CX
+	JGE  done32
+	MOVL (SI)(AX*4), R8
+	ADDL R8, (DI)(AX*4)
+	INCQ AX
+	JMP  tail32_1
+
+done32:
+	RET

--- a/internal/encoder/histogram_add_simd_amd64.s
+++ b/internal/encoder/histogram_add_simd_amd64.s
@@ -2,10 +2,10 @@
 
 #include "textflag.h"
 
-// func histogramAddSSE2Unrolled8x(dst, src []uint32, n int)
+// func histogramAddAsm(dst, src []uint32, n int)
 // Thirty-two uint32 per iteration. Deeper unrolling than the alphabet sizes
 // usually justify, included to show where the returns stop.
-TEXT ·histogramAddSSE2Unrolled8x(SB), NOSPLIT|NOFRAME, $0-56
+TEXT ·histogramAddAsm(SB), NOSPLIT|NOFRAME, $0-56
 	MOVQ dst_base+0(FP), DI
 	MOVQ src_base+24(FP), SI
 	MOVQ n+48(FP), CX

--- a/internal/encoder/histogram_add_simd_amd64.s
+++ b/internal/encoder/histogram_add_simd_amd64.s
@@ -1,7 +1,3 @@
-// Assembly for histogramAdd.go. SSE2 only: baseline on amd64, no CPU check
-// needed. Go assembly cannot live inside a .go file, which is why this is a
-// separate file rather than inlined with the rest.
-
 //go:build amd64 && !purego
 
 #include "textflag.h"

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -47,10 +47,10 @@ func TestHistogramAddSSE2LeavesEntriesPastAlphabetSizeUntouched(t *testing.T) {
 		src[i] = 7
 	}
 	histogramAddAsm(dst, src, n)
-	for i := range len(dst) {
-		if dst[i] != 0 {
+	for i, got := range dst[n:] {
+		if got != 0 {
 			t.Fatalf("index %d past alphabetSize was modified to %d; the histogram arena is "+
-				"contiguous, so writing past n corrupts the next histogram", i, dst[i])
+				"contiguous, so writing past n corrupts the next histogram", n+i, got)
 		}
 	}
 }

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -56,14 +56,14 @@ func TestHistogramAddSSE2LeavesEntriesPastAlphabetSizeUntouched(t *testing.T) {
 }
 
 func BenchmarkHistogramAdd704Symbols(b *testing.B) {
-	b.Run("impl=scalar", func(b *testing.B) {
+	b.Run("impl=OLD_scalar_loop", func(b *testing.B) {
 		dst, src := histogramAddFixture(b, 704)
 		b.ReportAllocs()
 		for range b.N {
 			histogramAddScalarReference(dst, src, 704)
 		}
 	})
-	b.Run("impl=sse2_v1", func(b *testing.B) {
+	b.Run("impl=NEW_sse2_asm", func(b *testing.B) {
 		dst, src := histogramAddFixture(b, 704)
 		b.ReportAllocs()
 		for range b.N {

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -26,7 +26,7 @@ func TestHistogramAddSSE2MatchesScalarAtEveryTailLength(t *testing.T) {
 		dstV, src := histogramAddFixture(t, n)
 		dstS := append([]uint32(nil), dstV...)
 
-		histogramAddSSE2Unrolled8x(dstV, src, n)
+		histogramAddAsm(dstV, src, n)
 		histogramAddScalarReference(dstS, src, n)
 
 		for i := range dstS {
@@ -46,8 +46,8 @@ func TestHistogramAddSSE2LeavesEntriesPastAlphabetSizeUntouched(t *testing.T) {
 	for i := range src {
 		src[i] = 7
 	}
-	histogramAddSSE2Unrolled8x(dst, src, n)
-	for i := n; i < len(dst); i++ {
+	histogramAddAsm(dst, src, n)
+	for i := range len(dst) {
 		if dst[i] != 0 {
 			t.Fatalf("index %d past alphabetSize was modified to %d; the histogram arena is "+
 				"contiguous, so writing past n corrupts the next histogram", i, dst[i])
@@ -67,7 +67,7 @@ func BenchmarkHistogramAdd704Symbols(b *testing.B) {
 		dst, src := histogramAddFixture(b, 704)
 		b.ReportAllocs()
 		for range b.N {
-			histogramAddSSE2Unrolled8x(dst, src, 704)
+			histogramAddAsm(dst, src, 704)
 		}
 	})
 }

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -1,6 +1,3 @@
-// Parity and benchmarks for the SSE2 histogramAdd kernel. Vector and scalar
-// live in one binary so the comparison carries no run-to-run drift.
-
 //go:build amd64 && !purego
 
 package encoder

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -1,0 +1,76 @@
+// Parity and benchmarks for the SSE2 histogramAdd kernel. Vector and scalar
+// live in one binary so the comparison carries no run-to-run drift.
+
+//go:build amd64 && !purego
+
+package encoder
+
+import "testing"
+
+func histogramAddScalarReference(dst, src []uint32, alphabetSize int) {
+	for i := range alphabetSize {
+		dst[i] += src[i]
+	}
+}
+
+func histogramAddFixture(tb testing.TB, n int) (dst, src []uint32) {
+	tb.Helper()
+	dst = make([]uint32, n)
+	src = make([]uint32, n)
+	for i := range dst {
+		dst[i] = uint32(i*2654435761) % 50000
+		src[i] = uint32(i*40503) % 50000
+	}
+	return dst, src
+}
+
+func TestHistogramAddSSE2MatchesScalarAtEveryTailLength(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 7, 8, 15, 16, 17, 31, 32, 33, 63, 64, 256, 704} {
+		dstV, src := histogramAddFixture(t, n)
+		dstS := append([]uint32(nil), dstV...)
+
+		histogramAddSSE2Unrolled8x(dstV, src, n)
+		histogramAddScalarReference(dstS, src, n)
+
+		for i := range dstS {
+			if dstV[i] != dstS[i] {
+				t.Fatalf("n=%d index %d: SSE2 8x-unrolled add produced %d, scalar produced "+
+					"%d; a wrong tail corrupts the merged histogram and changes output",
+					n, i, dstV[i], dstS[i])
+			}
+		}
+	}
+}
+
+func TestHistogramAddSSE2LeavesEntriesPastAlphabetSizeUntouched(t *testing.T) {
+	const n = 11
+	dst := make([]uint32, 64)
+	src := make([]uint32, 64)
+	for i := range src {
+		src[i] = 7
+	}
+	histogramAddSSE2Unrolled8x(dst, src, n)
+	for i := n; i < len(dst); i++ {
+		if dst[i] != 0 {
+			t.Fatalf("index %d past alphabetSize was modified to %d; the histogram arena is "+
+				"contiguous, so writing past n corrupts the next histogram", i, dst[i])
+		}
+	}
+}
+
+func BenchmarkHistogramAdd704Symbols(b *testing.B) {
+	b.Run("impl=scalar", func(b *testing.B) {
+		dst, src := histogramAddFixture(b, 704)
+		b.ReportAllocs()
+		for range b.N {
+			histogramAddScalarReference(dst, src, 704)
+		}
+	})
+	b.Run("impl=sse2_v1", func(b *testing.B) {
+		dst, src := histogramAddFixture(b, 704)
+		b.ReportAllocs()
+		for range b.N {
+			histogramAddSSE2Unrolled8x(dst, src, 704)
+		}
+	})
+}

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -56,7 +56,7 @@ func TestHistogramAddSSE2LeavesEntriesPastAlphabetSizeUntouched(t *testing.T) {
 }
 
 func BenchmarkHistogramAdd704Symbols(b *testing.B) {
-	b.Run("impl=OLD_scalar_loop", func(b *testing.B) {
+	b.Run("impl=scalar_loop", func(b *testing.B) {
 		dst, src := histogramAddFixture(b, 704)
 		b.ReportAllocs()
 		for range b.N {

--- a/internal/encoder/histogram_add_simd_amd64_test.go
+++ b/internal/encoder/histogram_add_simd_amd64_test.go
@@ -63,7 +63,7 @@ func BenchmarkHistogramAdd704Symbols(b *testing.B) {
 			histogramAddScalarReference(dst, src, 704)
 		}
 	})
-	b.Run("impl=NEW_sse2_asm", func(b *testing.B) {
+	b.Run("impl=sse2_asm", func(b *testing.B) {
 		dst, src := histogramAddFixture(b, 704)
 		b.ReportAllocs()
 		for range b.N {

--- a/internal/encoder/histogram_total_count_generic.go
+++ b/internal/encoder/histogram_total_count_generic.go
@@ -1,7 +1,3 @@
-// Scalar histogramTotalCount for every target the SSE version does not cover:
-// non-amd64 and purego builds. Byte-for-byte identical results; this is the
-// original loop unchanged.
-
 //go:build !amd64 || purego
 
 package encoder

--- a/internal/encoder/histogram_total_count_generic.go
+++ b/internal/encoder/histogram_total_count_generic.go
@@ -1,0 +1,16 @@
+// Scalar histogramTotalCount for every target the SSE version does not cover:
+// non-amd64 and purego builds. Byte-for-byte identical results; this is the
+// original loop unchanged.
+
+//go:build !amd64 || purego
+
+package encoder
+
+// histogramTotalCount sums all entries in a histogram.
+func histogramTotalCount(h []uint32, alphabetSize int) uint32 {
+	var total uint32
+	for i := range alphabetSize {
+		total += h[i]
+	}
+	return total
+}

--- a/internal/encoder/histogram_total_count_simd_amd64.go
+++ b/internal/encoder/histogram_total_count_simd_amd64.go
@@ -1,0 +1,36 @@
+// Drop-in replacement for histogramTotalCount.
+//
+// Replaces the scalar histogramTotalCount formerly in cluster.go — signature
+// unchanged.
+// Needs:    histogram_total_count_simd_amd64.s (same directory).
+//           histogram_total_count_generic.go for every other build target.
+//
+// Measured per microarchitecture level, 704 symbols, against the scalar loop:
+//
+//	v1  SSE2, four accumulators, PSHUFD fold    33.3 ns   +739%   <- selected
+//	v2  SSE4, four accumulators, PHADDD fold    33.5 ns   +734%
+//	v3  AVX2, masked tail                       48.2 ns   +460%
+//	v4  AVX-512, reslicing loop                 30.8 ns   +777%
+//
+// Only the v1 fold ships. PHADDD measured -0.6% against PSHUFD, inside noise,
+// so the SSSE3 dispatch was not worth a CPUID probe. AVX-512 does win in
+// isolation, but this kernel runs interleaved with populationCost's scalar
+// math.Log2 and the transition cost exceeds what the extra width saves.
+//
+// SSE2 is baseline on amd64, so this needs no feature check and is active in an
+// ordinary build at every GOAMD64 level.
+
+//go:build amd64 && !purego
+
+package encoder
+
+// histogramTotalCount sums all entries in a histogram.
+func histogramTotalCount(h []uint32, alphabetSize int) uint32 {
+	return histogramTotalCountSSE2FourAccum(h, alphabetSize)
+}
+
+// histogramTotalCountSSE2FourAccum sums with four independent accumulators and
+// folds them with PSHUFD. Implemented in histogram_total_count_simd_amd64.s.
+//
+//go:noescape
+func histogramTotalCountSSE2FourAccum(h []uint32, n int) uint32

--- a/internal/encoder/histogram_total_count_simd_amd64.go
+++ b/internal/encoder/histogram_total_count_simd_amd64.go
@@ -4,6 +4,7 @@ package encoder
 
 // histogramTotalCount sums all entries in a histogram.
 func histogramTotalCount(h []uint32, alphabetSize int) uint32 {
+	h = h[:alphabetSize]
 	return histogramTotalCountSSE2FourAccum(h, alphabetSize)
 }
 

--- a/internal/encoder/histogram_total_count_simd_amd64.go
+++ b/internal/encoder/histogram_total_count_simd_amd64.go
@@ -5,11 +5,11 @@ package encoder
 // histogramTotalCount sums all entries in a histogram.
 func histogramTotalCount(h []uint32, alphabetSize int) uint32 {
 	h = h[:alphabetSize]
-	return histogramTotalCountSSE2FourAccum(h, alphabetSize)
+	return histogramTotalCountAsm(h, alphabetSize)
 }
 
-// histogramTotalCountSSE2FourAccum sums with four independent accumulators and
+// histogramTotalCountAsm sums with four independent accumulators and
 // folds them with PSHUFD. Implemented in histogram_total_count_simd_amd64.s.
 //
 //go:noescape
-func histogramTotalCountSSE2FourAccum(h []uint32, n int) uint32
+func histogramTotalCountAsm(h []uint32, n int) uint32

--- a/internal/encoder/histogram_total_count_simd_amd64.go
+++ b/internal/encoder/histogram_total_count_simd_amd64.go
@@ -1,25 +1,3 @@
-// Drop-in replacement for histogramTotalCount.
-//
-// Replaces the scalar histogramTotalCount formerly in cluster.go — signature
-// unchanged.
-// Needs:    histogram_total_count_simd_amd64.s (same directory).
-//           histogram_total_count_generic.go for every other build target.
-//
-// Measured per microarchitecture level, 704 symbols, against the scalar loop:
-//
-//	v1  SSE2, four accumulators, PSHUFD fold    33.3 ns   +739%   <- selected
-//	v2  SSE4, four accumulators, PHADDD fold    33.5 ns   +734%
-//	v3  AVX2, masked tail                       48.2 ns   +460%
-//	v4  AVX-512, reslicing loop                 30.8 ns   +777%
-//
-// Only the v1 fold ships. PHADDD measured -0.6% against PSHUFD, inside noise,
-// so the SSSE3 dispatch was not worth a CPUID probe. AVX-512 does win in
-// isolation, but this kernel runs interleaved with populationCost's scalar
-// math.Log2 and the transition cost exceeds what the extra width saves.
-//
-// SSE2 is baseline on amd64, so this needs no feature check and is active in an
-// ordinary build at every GOAMD64 level.
-
 //go:build amd64 && !purego
 
 package encoder

--- a/internal/encoder/histogram_total_count_simd_amd64.s
+++ b/internal/encoder/histogram_total_count_simd_amd64.s
@@ -1,0 +1,66 @@
+// Assembly for histogramTotalCount.go. Go assembly cannot live inside a .go file.
+
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+// func histogramTotalCountSSE2FourAccum(h []uint32, n int) uint32
+// Four independent accumulators so the sum is not serialised on one PADDD.
+TEXT ·histogramTotalCountSSE2FourAccum(SB), NOSPLIT|NOFRAME, $0-36
+	MOVQ h_base+0(FP), SI
+	MOVQ n+24(FP), CX
+	XORQ AX, AX
+	PXOR X0, X0
+	PXOR X2, X2
+	PXOR X4, X4
+	PXOR X6, X6
+	MOVQ CX, DX
+	SUBQ $16, DX
+
+sum16:
+	CMPQ  AX, DX
+	JG    sum16fold
+	MOVOU (SI)(AX*4), X1
+	MOVOU 16(SI)(AX*4), X3
+	MOVOU 32(SI)(AX*4), X5
+	MOVOU 48(SI)(AX*4), X7
+	PADDL X1, X0
+	PADDL X3, X2
+	PADDL X5, X4
+	PADDL X7, X6
+	ADDQ  $16, AX
+	JMP   sum16
+
+sum16fold:
+	PADDL  X2, X0
+	PADDL  X6, X4
+	PADDL  X4, X0
+	MOVQ   CX, DX
+	SUBQ   $4, DX
+
+sum16_4:
+	CMPQ  AX, DX
+	JG    sum16_done
+	MOVOU (SI)(AX*4), X1
+	PADDL X1, X0
+	ADDQ  $4, AX
+	JMP   sum16_4
+
+sum16_done:
+	PSHUFD $0x0E, X0, X1
+	PADDL  X1, X0
+	PSHUFD $0x01, X0, X1
+	PADDL  X1, X0
+	MOVL   X0, R8
+
+sum16_scalar:
+	CMPQ AX, CX
+	JGE  sum16_ret
+	MOVL (SI)(AX*4), R9
+	ADDL R9, R8
+	INCQ AX
+	JMP  sum16_scalar
+
+sum16_ret:
+	MOVL R8, ret+32(FP)
+	RET

--- a/internal/encoder/histogram_total_count_simd_amd64.s
+++ b/internal/encoder/histogram_total_count_simd_amd64.s
@@ -4,9 +4,9 @@
 
 #include "textflag.h"
 
-// func histogramTotalCountSSE2FourAccum(h []uint32, n int) uint32
+// func histogramTotalCountAsm(h []uint32, n int) uint32
 // Four independent accumulators so the sum is not serialised on one PADDD.
-TEXT ·histogramTotalCountSSE2FourAccum(SB), NOSPLIT|NOFRAME, $0-36
+TEXT ·histogramTotalCountAsm(SB), NOSPLIT|NOFRAME, $0-36
 	MOVQ h_base+0(FP), SI
 	MOVQ n+24(FP), CX
 	XORQ AX, AX

--- a/internal/encoder/histogram_total_count_simd_amd64_test.go
+++ b/internal/encoder/histogram_total_count_simd_amd64_test.go
@@ -27,7 +27,7 @@ func TestHistogramTotalCountSSE2MatchesScalarAtEveryTailLength(t *testing.T) {
 	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 63, 64, 256, 704} {
 		h := histogramTotalCountFixture(t, n)
 		want := histogramTotalCountScalarReference(h, n)
-		if got := histogramTotalCountSSE2FourAccum(h, n); got != want {
+		if got := histogramTotalCountAsm(h, n); got != want {
 			t.Errorf("n=%d: PSHUFD fold summed to %d but the scalar loop gives %d; "+
 				"a wrong tail here silently corrupts every cost estimate", n, got, want)
 		}
@@ -50,7 +50,7 @@ func BenchmarkHistogramTotalCount704Symbols(b *testing.B) {
 	b.Run("impl=sse2_pshufd", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
-			histogramTotalCountSink = histogramTotalCountSSE2FourAccum(h, 704)
+			histogramTotalCountSink = histogramTotalCountAsm(h, 704)
 		}
 	})
 }

--- a/internal/encoder/histogram_total_count_simd_amd64_test.go
+++ b/internal/encoder/histogram_total_count_simd_amd64_test.go
@@ -41,7 +41,7 @@ func TestHistogramTotalCountSSE2MatchesScalarAtEveryTailLength(t *testing.T) {
 func BenchmarkHistogramTotalCount704Symbols(b *testing.B) {
 	h := histogramTotalCountFixture(b, 704)
 
-	b.Run("impl=OLD_scalar_loop", func(b *testing.B) {
+	b.Run("impl=scalar_loop", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
 			histogramTotalCountSink = histogramTotalCountScalarReference(h, 704)

--- a/internal/encoder/histogram_total_count_simd_amd64_test.go
+++ b/internal/encoder/histogram_total_count_simd_amd64_test.go
@@ -47,7 +47,7 @@ func BenchmarkHistogramTotalCount704Symbols(b *testing.B) {
 			histogramTotalCountSink = histogramTotalCountScalarReference(h, 704)
 		}
 	})
-	b.Run("impl=NEW_sse2_pshufd", func(b *testing.B) {
+	b.Run("impl=sse2_pshufd", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
 			histogramTotalCountSink = histogramTotalCountSSE2FourAccum(h, 704)

--- a/internal/encoder/histogram_total_count_simd_amd64_test.go
+++ b/internal/encoder/histogram_total_count_simd_amd64_test.go
@@ -1,0 +1,60 @@
+// Parity and benchmarks for the SSE2 histogramTotalCount kernel. The kernel and
+// the scalar reference live in one binary so the comparison carries no
+// run-to-run drift.
+
+//go:build amd64 && !purego
+
+package encoder
+
+import "testing"
+
+var histogramTotalCountSink uint32
+
+func histogramTotalCountScalarReference(h []uint32, alphabetSize int) uint32 {
+	var total uint32
+	for i := range alphabetSize {
+		total += h[i]
+	}
+	return total
+}
+
+func histogramTotalCountFixture(tb testing.TB, n int) []uint32 {
+	tb.Helper()
+	h := make([]uint32, n)
+	for i := range h {
+		h[i] = uint32(i*2654435761) % 100000
+	}
+	return h
+}
+
+func TestHistogramTotalCountSSE2MatchesScalarAtEveryTailLength(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 63, 64, 256, 704} {
+		h := histogramTotalCountFixture(t, n)
+		want := histogramTotalCountScalarReference(h, n)
+		if got := histogramTotalCountSSE2FourAccum(h, n); got != want {
+			t.Errorf("n=%d: PSHUFD fold summed to %d but the scalar loop gives %d; "+
+				"a wrong tail here silently corrupts every cost estimate", n, got, want)
+		}
+		if got := histogramTotalCount(h, n); got != want {
+			t.Errorf("n=%d: histogramTotalCount summed to %d but the scalar loop gives "+
+				"%d, so the drop-in replacement is not equivalent", n, got, want)
+		}
+	}
+}
+
+func BenchmarkHistogramTotalCount704Symbols(b *testing.B) {
+	h := histogramTotalCountFixture(b, 704)
+
+	b.Run("impl=OLD_scalar_loop", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			histogramTotalCountSink = histogramTotalCountScalarReference(h, 704)
+		}
+	})
+	b.Run("impl=NEW_sse2_pshufd", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			histogramTotalCountSink = histogramTotalCountSSE2FourAccum(h, 704)
+		}
+	})
+}

--- a/internal/encoder/histogram_total_count_simd_amd64_test.go
+++ b/internal/encoder/histogram_total_count_simd_amd64_test.go
@@ -1,7 +1,3 @@
-// Parity and benchmarks for the SSE2 histogramTotalCount kernel. The kernel and
-// the scalar reference live in one binary so the comparison carries no
-// run-to-run drift.
-
 //go:build amd64 && !purego
 
 package encoder

--- a/internal/encoder/prefix2mask_generic.go
+++ b/internal/encoder/prefix2mask_generic.go
@@ -1,0 +1,10 @@
+//go:build !amd64 || purego
+
+package encoder
+
+// prefix2Mask64Available reports that no SIMD kernel is compiled in.
+const prefix2Mask64Available = false
+
+// prefix2Mask64 is never called on this target; it exists so the dispatch
+// compiles.
+func prefix2Mask64(p *byte, c0, c1 byte) uint64 { return 0 }

--- a/internal/encoder/prefix2mask_simd_amd64.go
+++ b/internal/encoder/prefix2mask_simd_amd64.go
@@ -1,0 +1,12 @@
+//go:build amd64 && !purego
+
+package encoder
+
+// prefix2Mask64Available reports that the SSE2 kernel is compiled in.
+const prefix2Mask64Available = true
+
+// prefix2Mask64 returns a bitmask whose bit j is set when p[j] == c0 and
+// p[j+1] == c1. It reads 65 bytes starting at p.
+//
+//go:noescape
+func prefix2Mask64(p *byte, c0, c1 byte) uint64

--- a/internal/encoder/prefix2mask_simd_amd64.s
+++ b/internal/encoder/prefix2mask_simd_amd64.s
@@ -1,0 +1,59 @@
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+// func prefix2Mask64(p *byte, c0, c1 byte) uint64
+// Bit j is set when p[j] == c0 && p[j+1] == c1, for j in [0,64).
+// Reads 65 bytes from p. SSE2 only, so the byte broadcast goes through
+// PUNPCKLBW/PSHUFLW/PSHUFD rather than PSHUFB.
+TEXT ·prefix2Mask64(SB), NOSPLIT|NOFRAME, $0-24
+	MOVQ    p+0(FP), SI
+	MOVBLZX c0+8(FP), AX
+	MOVBLZX c1+9(FP), BX
+
+	MOVD      AX, X0
+	PUNPCKLBW X0, X0
+	PSHUFLW   $0, X0, X0
+	PSHUFD    $0, X0, X0
+
+	MOVD      BX, X1
+	PUNPCKLBW X1, X1
+	PSHUFLW   $0, X1, X1
+	PSHUFD    $0, X1, X1
+
+	MOVOU   0(SI), X2
+	MOVOU   1(SI), X3
+	PCMPEQB X0, X2
+	PCMPEQB X1, X3
+	PAND    X3, X2
+	PMOVMSKB X2, R9
+
+	MOVOU   16(SI), X4
+	MOVOU   17(SI), X5
+	PCMPEQB X0, X4
+	PCMPEQB X1, X5
+	PAND    X5, X4
+	PMOVMSKB X4, R10
+	SHLQ    $16, R10
+	ORQ     R10, R9
+
+	MOVOU   32(SI), X6
+	MOVOU   33(SI), X7
+	PCMPEQB X0, X6
+	PCMPEQB X1, X7
+	PAND    X7, X6
+	PMOVMSKB X6, R11
+	SHLQ    $32, R11
+	ORQ     R11, R9
+
+	MOVOU   48(SI), X8
+	MOVOU   49(SI), X9
+	PCMPEQB X0, X8
+	PCMPEQB X1, X9
+	PAND    X9, X8
+	PMOVMSKB X8, R12
+	SHLQ    $48, R12
+	ORQ     R12, R9
+
+	MOVQ R9, ret+16(FP)
+	RET

--- a/internal/encoder/prefix2mask_simd_amd64_test.go
+++ b/internal/encoder/prefix2mask_simd_amd64_test.go
@@ -68,7 +68,7 @@ func BenchmarkPrefix2Mask64(b *testing.B) {
 			prefix2MaskSink = prefix2Mask64Scalar(data, 0, c0, c1)
 		}
 	})
-	b.Run("impl=NEW_sse2_mask", func(b *testing.B) {
+	b.Run("impl=sse2_mask", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
 			prefix2MaskSink = prefix2Mask64(&data[0], c0, c1)

--- a/internal/encoder/prefix2mask_simd_amd64_test.go
+++ b/internal/encoder/prefix2mask_simd_amd64_test.go
@@ -74,7 +74,7 @@ func BenchmarkPrefix2Mask64(b *testing.B) {
 			prefix2MaskSink = prefix2Mask64(&data[0], c0, c1)
 		}
 	})
-	b.Run("impl=NEW_sse2_mask_plus_walk", func(b *testing.B) {
+	b.Run("impl=sse2_mask_plus_walk", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
 			m := prefix2Mask64(&data[0], c0, c1)

--- a/internal/encoder/prefix2mask_simd_amd64_test.go
+++ b/internal/encoder/prefix2mask_simd_amd64_test.go
@@ -34,8 +34,8 @@ func TestPrefix2Mask64MatchesScalarForEveryBytePair(t *testing.T) {
 	for _, seed := range []int{1, 3, 11, 97} {
 		data := prefix2MaskFixture(t, seed)
 		for _, off := range []int{0, 1, 7, 64, 100} {
-			for c0 := byte(0); c0 < 8; c0++ {
-				for c1 := byte(0); c1 < 8; c1++ {
+			for c0 := range byte(8) {
+				for c1 := range byte(8) {
 					got := prefix2Mask64(&data[off], c0, c1)
 					want := prefix2Mask64Scalar(data, off, c0, c1)
 					if got != want {

--- a/internal/encoder/prefix2mask_simd_amd64_test.go
+++ b/internal/encoder/prefix2mask_simd_amd64_test.go
@@ -62,7 +62,7 @@ func TestPrefix2Mask64AllOnesAndAllZeroes(t *testing.T) {
 func BenchmarkPrefix2Mask64(b *testing.B) {
 	data := prefix2MaskFixture(b, 11)
 	c0, c1 := data[64], data[65]
-	b.Run("impl=OLD_scalar_scan", func(b *testing.B) {
+	b.Run("impl=scalar_scan", func(b *testing.B) {
 		b.ReportAllocs()
 		for range b.N {
 			prefix2MaskSink = prefix2Mask64Scalar(data, 0, c0, c1)

--- a/internal/encoder/prefix2mask_simd_amd64_test.go
+++ b/internal/encoder/prefix2mask_simd_amd64_test.go
@@ -1,0 +1,90 @@
+//go:build amd64 && !purego
+
+package encoder
+
+import (
+	"math/bits"
+	"testing"
+)
+
+var prefix2MaskSink uint64
+
+// prefix2Mask64Scalar is the loop the kernel replaces: bit j set when the
+// two-byte prefix at p[j] matches.
+func prefix2Mask64Scalar(data []byte, off int, c0, c1 byte) uint64 {
+	var m uint64
+	for j := range 64 {
+		if data[off+j] == c0 && data[off+j+1] == c1 {
+			m |= 1 << uint(j)
+		}
+	}
+	return m
+}
+
+func prefix2MaskFixture(tb testing.TB, seed int) []byte {
+	tb.Helper()
+	d := make([]byte, 256)
+	for i := range d {
+		d[i] = byte((i*seed + i/3) % 7)
+	}
+	return d
+}
+
+func TestPrefix2Mask64MatchesScalarForEveryBytePair(t *testing.T) {
+	for _, seed := range []int{1, 3, 11, 97} {
+		data := prefix2MaskFixture(t, seed)
+		for _, off := range []int{0, 1, 7, 64, 100} {
+			for c0 := byte(0); c0 < 8; c0++ {
+				for c1 := byte(0); c1 < 8; c1++ {
+					got := prefix2Mask64(&data[off], c0, c1)
+					want := prefix2Mask64Scalar(data, off, c0, c1)
+					if got != want {
+						t.Fatalf("seed=%d off=%d c0=%d c1=%d: kernel %064b, scalar %064b; a "+
+							"wrong bit changes which candidate the encoder tries and so the output",
+							seed, off, c0, c1, got, want)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestPrefix2Mask64AllOnesAndAllZeroes(t *testing.T) {
+	same := make([]byte, 128)
+	if got := prefix2Mask64(&same[0], 0, 0); got != ^uint64(0) {
+		t.Fatalf("uniform buffer: got %064b, want all ones", got)
+	}
+	if got := prefix2Mask64(&same[0], 1, 1); got != 0 {
+		t.Fatalf("no match anywhere: got %064b, want zero", got)
+	}
+}
+
+func BenchmarkPrefix2Mask64(b *testing.B) {
+	data := prefix2MaskFixture(b, 11)
+	c0, c1 := data[64], data[65]
+	b.Run("impl=OLD_scalar_scan", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			prefix2MaskSink = prefix2Mask64Scalar(data, 0, c0, c1)
+		}
+	})
+	b.Run("impl=NEW_sse2_mask", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			prefix2MaskSink = prefix2Mask64(&data[0], c0, c1)
+		}
+	})
+	b.Run("impl=NEW_sse2_mask_plus_walk", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			m := prefix2Mask64(&data[0], c0, c1)
+			var n uint64
+			for m != 0 {
+				j := uint(63 - bits.LeadingZeros64(m))
+				m &^= 1 << j
+				n += uint64(j)
+			}
+			prefix2MaskSink = n
+		}
+	})
+}


### PR DESCRIPTION
```
# GOAMD64=v1 CGO_ENABLED=1 go test -run '^$' -bench BenchmarkHistogramAdd704Symbols -benchmem -count=6 ./internal/encoder/
goos: linux
goarch: amd64
pkg: github.com/molecule-man/go-brrr/internal/encoder
cpu: AMD EPYC-Genoa Processor
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3778959               345.3 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3059192               346.6 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3619747               344.4 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3278760               332.8 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3532142               334.2 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=scalar-20           3574701               341.6 ns/op             0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         17970943                74.75 ns/op            0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         17618890                75.36 ns/op            0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         17270004                74.36 ns/op            0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         17975302                73.99 ns/op            0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         16177279                74.22 ns/op            0 B/op          0 allocs/op
BenchmarkHistogramAdd704Symbols/impl=sse2_v1-20         18051702                74.85 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/molecule-man/go-brrr/internal/encoder        17.511s
```